### PR TITLE
Clean: remove lodash.clonedeep from dependencies and related imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -914,19 +914,6 @@
         "jest-diff": "^24.3.0"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.149",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
-    },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -7858,11 +7845,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.flatmap": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
       "git add"
     ]
   },
-  "dependencies": {
-    "@types/lodash.clonedeep": "^4.5.6",
-    "lodash.clonedeep": "^4.5.0"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/src/attach.tsx
+++ b/src/attach.tsx
@@ -1,5 +1,4 @@
-import cloneDeep from 'lodash.clonedeep';
-import React, { useState } from 'react';
+import React from 'react';
 import { error, isAttachWrapper, isClassComponent } from './common/utils';
 import { getPoolView } from './pool/pools';
 import { IAttach, IScaxerManager, TAttachedComponentType, TScaxerSubscriberType } from './types';


### PR DESCRIPTION
Remove lodash.clonedeep from dependencies and clean the related imports.